### PR TITLE
include aar in android build

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,8 @@ Flutter plugin for MDS (Movesense Device Service) that is used for communicating
 
 #### Android
 
-1. Download 'mdslib-x.x.x-release.aar' from movesense-mobile-lib repository and put it somewhere under 'android' folder of your app. Preferably create a new folder named 'android/libs' and put it there.
+No extra steps are required
 
-2. In 'build.gradle' of your android project, add the following lines (assuming .aar file is in android/libs):
-```
-allprojects {
-    repositories {
-        ...
-        flatDir{
-            dirs "$rootDir/libs"
-        }
-    }
-}
-```
 ## Usage
 
 ```dart

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,6 +19,13 @@ rootProject.allprojects {
     repositories {
         google()
         jcenter()
+        flatDir {
+            if (findProject(':mdsflutter') != null) {
+                dirs project(":mdsflutter").file('libs')
+            } else {
+                dirs file('libs')
+            }
+        }
     }
 }
 
@@ -71,5 +78,5 @@ dependencies {
     implementation 'com.google.protobuf:protobuf-lite:3.0.1'
     // RxAndroidBle helper library
     implementation "com.polidea.rxandroidble2:rxandroidble:1.11.0"
-    implementation(name: 'mdslib', version: '+', ext: 'aar')
+    implementation (name: 'mdslib-1.44.0', ext: 'aar')
 }


### PR DESCRIPTION
This pull request changes the way the `aar` module is included within the project.

If this gets merged the end user doesn't need to add the `aar` step manually.